### PR TITLE
Add BuyWhere MCP server to community registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ npx @michaellatman/mcp-get@latest list
 - **[LLM.txt Server](src/server-llm-txt)** - A server for searching and retrieving content from [LLM.txt](https://llmstxt.org/) files. Provides tools for listing available files, fetching content, and performing contextual searches.
 - **[Curl Server](src/server-curl)** - A server that allows LLMs to make HTTP requests to any URL using a curl-like interface. Supports all common HTTP methods, custom headers, request body, and configurable timeouts.
 - **[macOS Server](src/server-macos)** - A server that provides macOS-specific system information and operations.
+- **[BuyWhere Server](src/server-buywhere)** - Product search and price comparison for AI agents across Singapore, SEA, and US markets. Search 11M+ products across Shopee, Lazada, Amazon, Walmart, and 20+ platforms.
 
 ## Installation
 

--- a/src/server-buywhere/LICENSE
+++ b/src/server-buywhere/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 BuyWhere
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/server-buywhere/README.md
+++ b/src/server-buywhere/README.md
@@ -1,0 +1,59 @@
+# BuyWhere MCP Server
+
+A Model Context Protocol (MCP) server for [BuyWhere](https://buywhere.ai) — search and compare 11M+ products across Singapore, SEA, and US markets via AI agents.
+
+## Features
+
+- **Product search** across Shopee, Lazada, Amazon, Walmart, FairPrice, Carousell, and 20+ platforms
+- **Price comparison** for 2–5 products side by side
+- **Real-time pricing** across merchants
+- **Affiliate links** for tracked product URLs
+- **Category taxonomy** for structured browsing
+- Markets: Singapore (sg), Malaysia (my), USA (us), Australia (au), Philippines (ph), Indonesia (id)
+
+## Installation
+
+```bash
+npx @michaellatman/mcp-get@latest install @mcp-get-community/server-buywhere
+```
+
+## Configuration
+
+Set your BuyWhere API key as an environment variable. Get a free key at [buywhere.ai/api-keys](https://buywhere.ai/api-keys).
+
+```json
+{
+  "mcpServers": {
+    "buywhere": {
+      "command": "npx",
+      "args": ["-y", "@mcp-get-community/server-buywhere"],
+      "env": {
+        "BUYWHERE_API_KEY": "bw_live_xxxx"
+      }
+    }
+  }
+}
+```
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `search_products` | Search by keyword, category, price range, and market |
+| `get_product` | Full product details by BuyWhere product ID |
+| `get_price` | Current prices across merchants |
+| `compare_prices` | Side-by-side comparison of 2–5 products |
+| `get_affiliate_link` | Click-tracked outbound link for a product |
+| `get_catalog` | Browse category taxonomy |
+
+## Development
+
+```bash
+npm install
+npm run build
+npm start
+```
+
+## License
+
+MIT — see [LICENSE](LICENSE)

--- a/src/server-buywhere/package.json
+++ b/src/server-buywhere/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@mcp-get-community/server-buywhere",
+  "version": "0.1.0",
+  "description": "BuyWhere MCP server for AI agents — search and compare 11M+ products across Singapore, SEA, and US markets via Model Context Protocol",
+  "main": "dist/index.js",
+  "type": "module",
+  "private": false,
+  "bin": {
+    "@mcp-get-community/server-buywhere": "./dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "MIT",
+  "author": "Michael Latman <https://michaellatman.com>",
+  "homepage": "https://github.com/BuyWhere/buywhere-mcp#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mcp-get/community-servers.git",
+    "directory": "src/server-buywhere"
+  },
+  "bugs": {
+    "url": "https://github.com/mcp-get/community-servers/issues"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "ts-node src/index.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.0.1",
+    "node-fetch": "^3.3.0",
+    "zod": "^3.22.4",
+    "zod-to-json-schema": "^3.22.3"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "typescript": "^5.3.0",
+    "ts-node": "^10.9.0"
+  }
+}

--- a/src/server-buywhere/src/index.ts
+++ b/src/server-buywhere/src/index.ts
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  type CallToolRequest
+} from "@modelcontextprotocol/sdk/types.js";
+import fetch from "node-fetch";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+const API_BASE = "https://api.buywhere.ai/v1";
+const API_KEY = process.env.BUYWHERE_API_KEY;
+
+const SearchProductsSchema = z.object({
+  query: z.string().describe("Product search keyword"),
+  market: z.enum(["sg", "my", "us", "au", "ph", "id"]).optional().describe("Market/region code (sg=Singapore, my=Malaysia, us=USA, au=Australia, ph=Philippines, id=Indonesia)"),
+  category: z.string().optional().describe("Product category filter"),
+  min_price: z.number().optional().describe("Minimum price filter"),
+  max_price: z.number().optional().describe("Maximum price filter"),
+  limit: z.number().min(1).max(50).default(10).describe("Number of results to return")
+});
+
+const GetProductSchema = z.object({
+  product_id: z.string().describe("BuyWhere product ID")
+});
+
+const GetPriceSchema = z.object({
+  product_id: z.string().describe("BuyWhere product ID")
+});
+
+const ComparePricesSchema = z.object({
+  product_ids: z.array(z.string()).min(2).max(5).describe("Array of 2–5 BuyWhere product IDs to compare")
+});
+
+const GetAffiliateLinkSchema = z.object({
+  product_id: z.string().describe("BuyWhere product ID")
+});
+
+const GetCatalogSchema = z.object({
+  market: z.enum(["sg", "my", "us", "au", "ph", "id"]).optional().describe("Market/region code")
+});
+
+const tools = {
+  search_products: {
+    description: "Search BuyWhere product catalog by keyword, category, price range, and market. Returns product listings from Shopee, Lazada, Amazon, Walmart, and 20+ platforms.",
+    inputSchema: zodToJsonSchema(SearchProductsSchema)
+  },
+  get_product: {
+    description: "Get full product details by BuyWhere product ID, including price, specs, images, and merchant info.",
+    inputSchema: zodToJsonSchema(GetProductSchema)
+  },
+  get_price: {
+    description: "Get current prices for a product across all merchants.",
+    inputSchema: zodToJsonSchema(GetPriceSchema)
+  },
+  compare_prices: {
+    description: "Compare 2–5 products side by side with best-value guidance.",
+    inputSchema: zodToJsonSchema(ComparePricesSchema)
+  },
+  get_affiliate_link: {
+    description: "Get a click-tracked affiliate URL for a product.",
+    inputSchema: zodToJsonSchema(GetAffiliateLinkSchema)
+  },
+  get_catalog: {
+    description: "Browse the BuyWhere category taxonomy for a market.",
+    inputSchema: zodToJsonSchema(GetCatalogSchema)
+  }
+};
+
+const server = new Server(
+  { name: "@mcp-get-community/server-buywhere", version: "0.1.0", author: "BuyWhere" },
+  { capabilities: { tools } }
+);
+
+function headers() {
+  const h: Record<string, string> = { "Content-Type": "application/json" };
+  if (API_KEY) h["Authorization"] = `Bearer ${API_KEY}`;
+  return h;
+}
+
+async function apiGet(path: string): Promise<unknown> {
+  const res = await fetch(`${API_BASE}${path}`, { headers: headers() });
+  if (!res.ok) throw new Error(`BuyWhere API error ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+async function apiPost(path: string, body: unknown): Promise<unknown> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: "POST",
+    headers: headers(),
+    body: JSON.stringify(body)
+  });
+  if (!res.ok) throw new Error(`BuyWhere API error ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: Object.entries(tools).map(([name, def]) => ({ name, ...def }))
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest) => {
+  const { name, arguments: args } = request.params;
+  try {
+    let result: unknown;
+    switch (name) {
+      case "search_products": {
+        const params = SearchProductsSchema.parse(args);
+        const qs = new URLSearchParams({ q: params.query, limit: String(params.limit) });
+        if (params.market) qs.set("market", params.market);
+        if (params.category) qs.set("category", params.category);
+        if (params.min_price !== undefined) qs.set("min_price", String(params.min_price));
+        if (params.max_price !== undefined) qs.set("max_price", String(params.max_price));
+        result = await apiGet(`/search?${qs}`);
+        break;
+      }
+      case "get_product": {
+        const { product_id } = GetProductSchema.parse(args);
+        result = await apiGet(`/products/${product_id}`);
+        break;
+      }
+      case "get_price": {
+        const { product_id } = GetPriceSchema.parse(args);
+        result = await apiGet(`/products/${product_id}/prices`);
+        break;
+      }
+      case "compare_prices": {
+        const { product_ids } = ComparePricesSchema.parse(args);
+        result = await apiPost("/compare", { product_ids });
+        break;
+      }
+      case "get_affiliate_link": {
+        const { product_id } = GetAffiliateLinkSchema.parse(args);
+        result = await apiGet(`/products/${product_id}/affiliate`);
+        break;
+      }
+      case "get_catalog": {
+        const params = GetCatalogSchema.parse(args);
+        const qs = params.market ? `?market=${params.market}` : "";
+        result = await apiGet(`/catalog${qs}`);
+        break;
+      }
+      default:
+        throw new Error(`Unknown tool: ${name}`);
+    }
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    return {
+      content: [{ type: "text", text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+      isError: true
+    };
+  }
+});
+
+async function main() {
+  if (!API_KEY) {
+    process.stderr.write("Warning: BUYWHERE_API_KEY not set. Set it to enable authenticated requests.\n");
+  }
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`Fatal: ${err}\n`);
+  process.exit(1);
+});

--- a/src/server-buywhere/tsconfig.json
+++ b/src/server-buywhere/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Add `@mcp-get-community/server-buywhere`

Adds the **BuyWhere** MCP server — a price-comparison & product-search server for the BuyWhere catalog (electronics, grocery, and more across SG/US markets).

### Tools
- `search_products` — search the catalog by query/category/country
- `get_product` — fetch a single product
- `get_price` — current price for a product
- `compare_prices` — compare prices across merchants
- `get_affiliate_link` — affiliate/buy link for a product
- `get_catalog` — browse catalog categories

### Notes
- Full TypeScript package under `src/server-buywhere/` (LICENSE, README, package.json, tsconfig, src/index.ts)
- Backed by the public BuyWhere API (api.buywhere.ai)

Thanks for maintaining the community registry!